### PR TITLE
fix: add removeEventListener type

### DIFF
--- a/public/js/bootstrap.bundle.js
+++ b/public/js/bootstrap.bundle.js
@@ -7124,7 +7124,7 @@
     }
 
     if (_386.scrollLock.listener) {
-      window.removeEventListener(_386.scrollLock.listener);
+      window.removeEventListener("scroll", _386.scrollLock.listener);
       _386.scrollLock.listener = false;
     } else {
       if (!('paddingStart' in _386.scrollLock)) {


### PR DESCRIPTION
# ERROR
```
EventTarget.removeEventListener: At least 2 arguments required, but only 1 passed
_386.scrollLock@http://localhost:3000/js/bootstrap.bundle.js:7127:14
./src/App.tsx/componentDidMount/<@http://localhost:3000/static/js/bundle.js:57:19
```